### PR TITLE
Update join regex - support for IPv6 format

### DIFF
--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -62,7 +62,7 @@ mark2.umask.sock=666
 # Regular expressions to match for player join, quit and chat events
 # These use python regex syntax: http://docs.python.org/library/re.html
 # Backslashes *must* be doubled or they will be stripped.
-mark2.regex.join=(?P<username>[A-Za-z0-9_]{1,16})\\[.*/(?P<ip>[0-9\\.]+):\\d+\\] logged in with entity id .+
+mark2.regex.join=(?P<username>[A-Za-z0-9_]{1,16}).*\\[\/(?P<ip>[0-9.:%]*)\\] logged in with entity id .+
 mark2.regex.quit=(?P<username>[A-Za-z0-9_]{1,16}) lost connection: (?P<reason>.+)
 mark2.regex.chat=<(?P<username>[A-Za-z0-9_]{1,16})> (?P<message>.+)
 


### PR DESCRIPTION
Old regxp (not supporting IPv6) - https://regex101.com/r/lIGqg2/2/

New regxp:
- IPv6 https://regex101.com/r/lIGqg2/1
- IPv4 https://regex101.com/r/EGuoJa/1/